### PR TITLE
Make skip links visible on keyboard focus

### DIFF
--- a/components/carousel/carousel.css
+++ b/components/carousel/carousel.css
@@ -1,4 +1,5 @@
 /* Mobile Styles */
+
 .carousel-wrapper {
   margin: 20px;
   box-sizing: border-box; }
@@ -29,6 +30,11 @@
 
 .carousel .card {
   padding: 10px; }
+
+/* Local solution to possible global issue: making skip links visible on focus */
+.carousel-wrapper .element-invisible:focus {
+  position: static !important;
+}
 
 /* Tablet Styles */
 /* Desktop Styles */


### PR DESCRIPTION
Makes skip links visible on keyboard focus. There's no additional styling, but I think this should maybe be handled on a global level anyways because it's overriding the global .element-invisible class.

CC: @mikequattrin, @kristenakamura (re: global vs component level control of element visibility)