### PR TITLE
Add Escape key support for submenu and improve focus visibility

### DIFF
--- a/src/components/header/_global-navigation.scss
+++ b/src/components/header/_global-navigation.scss
@@ -292,6 +292,10 @@
 
     @media only screen and (min-width: $menu-collapse) {
       position: absolute;
+      // CHANGE: Add border outline around submenu
+      border: 2px solid $black;
+      border-radius: 4px;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }
 
     .has-submenu.open & {

--- a/src/components/header/global-navigation.js
+++ b/src/components/header/global-navigation.js
@@ -31,6 +31,31 @@ function removeDocumentClickHandler() {
   window.removeEventListener('click', onDocumentClick);
 }
 
+// Add escape key handler to close open submenus
+function onEscapeKey(event) {
+  if (event.key === 'Escape' || event.keyCode === 27) {
+    if (activeMenuItem) {
+      closeMenu(activeMenuItem);
+      removeDocumentClickHandler();
+      removeEscapeKeyHandler();
+      // CHANGE: Use requestAnimationFrame to ensure DOM updates complete before focusing
+      requestAnimationFrame(function() {
+        activeMenuItem.focus();
+      });
+    }
+  }
+}
+
+// Add escape key event listener when submenu opens
+function addEscapeKeyHandler() {
+  document.addEventListener('keydown', onEscapeKey);
+}
+
+// Remove escape key event listener when submenu closes
+function removeEscapeKeyHandler() {
+  document.removeEventListener('keydown', onEscapeKey);
+}
+
 function getActiveElement() {
   // the active element (with focus) isn't available yet when the blur event fires
   // so we kick this function down the stack a little with setTimeout
@@ -57,7 +82,12 @@ function closeMenu(element) {
   if (element && element.parentNode.classList.contains('open')) {
     element.parentNode.classList.remove('open');
     element.setAttribute('aria-expanded', 'false');
+    // CHANGE: Use requestAnimationFrame for consistent focus visibility after DOM updates
+    requestAnimationFrame(function() {
+      element.focus();
+    });
     activeMenuItem = null;
+    removeEscapeKeyHandler();
   }
 }
 
@@ -68,6 +98,8 @@ function openMenu(element) {
   element.setAttribute('aria-expanded', 'true');
   activeMenuItem = element;
   addDocumentClickHandler();
+  // CHANGE: Add escape key handler when menu opens
+  addEscapeKeyHandler();
 }
 
 function onClickMenuItemWithSubmenu(event) {


### PR DESCRIPTION
Adds keyboard support to close open submenus using the Escape key and returns focus to the trigger element. Also introduces visible outline styling for submenu items to improve focus visibility and keyboard navigation.