### PR TITLE
Update article to div for product tile

### DIFF
--- a/src/components/product-tile/product-tile.hbs
+++ b/src/components/product-tile/product-tile.hbs
@@ -1,7 +1,7 @@
-<article class="productGrid__product-tile product-tile">
+<div class="productGrid__product-tile product-tile">
     <a class="product-tile__link" href="../pdp/index.html?product_id={{product_id}}" aria-label="{{product_name}}, ${{price_sale}}, product details">
         <img class="product-tile__image" src="../{{thumbnail_url}}" alt="">
         <p class="product-tile__product-name">{{product_name}}</p>
         <span class="product-tile__price">${{price_sale}}</span>
     </a>
-</article>
+</div>


### PR DESCRIPTION
Changed article tag to div tag for product tile due to improper semantics (a product tile is not an article).